### PR TITLE
Use 'remotes' package to install development version

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ In Ubuntu Linux, execute the command `sudo apt-get install r-base-dev` in a Term
 
 ### Install package
 
-Once the compilers have been installed, then install the `devtools` package in R and run:
+Once the compilers have been installed, then install the `remotes` package in R and run:
 
 ```
-library(devtools)
+library(remotes)
 install_github("tjmckinley/SimBIID")
 ```
 


### PR DESCRIPTION
The `remotes` package is a lightweight replacement of functions in `devtools` to install packages from remote repositories (https://cran.r-project.org/web/packages/remotes/index.html)